### PR TITLE
internal: add new types to get the scope and the type of the focused …

### DIFF
--- a/packages/core/src/PureReadOptic.ts
+++ b/packages/core/src/PureReadOptic.ts
@@ -6,7 +6,7 @@ export const tag: unique symbol = Symbol('tag');
 export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     get(s: S): FocusedValue<A, TScope>;
     derive<B>(get: (a: NonNullable<A>) => B): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
-    [tag]: [opticScope: TScope, root: S, invariance: (a: A, s: S) => void];
+    [tag]: [scope: TScope, root: S, invariance: (a: A, s: S) => void];
 }
 
 type DeriveFromProps<A, TScope extends OpticScope, S, T = NonNullable<A>> = T extends Record<any, any>

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -83,7 +83,7 @@ describe('useOptic', () => {
         const _: [number] = result.current;
     });
 });
-describe('useKeyedOptics', () => {
+describe('useDeriveOptics', () => {
     const Number = memo(({ onNumber }: { onNumber: Optic<number> }) => {
         const [n] = useOptic(onNumber);
         const renders = useRef(0);

--- a/packages/react/src/useDeriveOptics.ts
+++ b/packages/react/src/useDeriveOptics.ts
@@ -1,6 +1,7 @@
-import { Lens, Optic, partial } from '@optics/state';
+import { GetOpticFocus, GetOpticScope, Lens, OpticScope, ReadOptic, total } from '@optics/state';
 import { useOptic } from './useOptic';
 import { useRef } from 'react';
+import { Resolve } from '@optics/state/src/combinators';
 
 const focusIndex = (index: number): Lens<any, any[]> => ({
     get: (s) => s[index],
@@ -8,13 +9,14 @@ const focusIndex = (index: number): Lens<any, any[]> => ({
     key: 'focus ' + index,
 });
 
-export function useDeriveOptics<T, TScope extends partial>(
-    onArray: Optic<T[], TScope>,
-    getKey: (t: T) => string,
-): [key: string, optic: Optic<T, TScope>][] {
+export function useDeriveOptics<
+    TOptic extends ReadOptic<any[], any>,
+    T extends any[] = GetOpticFocus<TOptic>,
+    TScope extends OpticScope = GetOpticScope<TOptic>,
+>(onArray: TOptic, getKey: (t: T) => string): [key: string, optic: Resolve<TOptic, T[number], TScope>][] {
     const [array = []] = useOptic(onArray, { denormalize: false });
 
-    const cachedOptics = useRef<Record<string, Optic<T, TScope>>>({});
+    const cachedOptics = useRef<Record<string, Resolve<TOptic, T[number], TScope>>>({});
 
     const derivedOptics = array.reduce<(typeof cachedOptics)['current']>((acc, cv, ci) => {
         const key = getKey(cv);

--- a/packages/state/src/Optics/ReadOptic.ts
+++ b/packages/state/src/Optics/ReadOptic.ts
@@ -5,7 +5,7 @@ import { GetStateOptions, SubscribeOptions } from '../types';
 export const tag: unique symbol = Symbol('tag');
 
 export type Denormalized<T> = [T] extends [
-    { [tag]: [opticScope: infer TScope extends OpticScope, focus: infer R, invariance: any] },
+    { [tag]: [scope: infer TScope extends OpticScope, focus: infer R, invariance: any] },
 ]
     ? Denormalized<FocusedValue<R, TScope>>
     : T extends Date
@@ -55,7 +55,7 @@ export interface _ReadOptic<A, TScope extends OpticScope> {
         listener: (a: ResolvedType<A, TScope, TOptions>) => void,
         options?: TOptions,
     ): () => void;
-    [tag]: [opticScope: TScope, focus: A, invariance: (a: A) => void];
+    [tag]: [scope: TScope, focus: A, invariance: (a: A) => void];
 }
 
 export type ReadOptic<A, TScope extends OpticScope = total> = _ReadOptic<A, TScope> &

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -4,4 +4,4 @@ export { Optic } from './Optics/Optic';
 export { ReadOptic, ResolvedType } from './Optics/ReadOptic';
 export { AsyncOptic } from './Optics/AsyncOptic';
 export { AsyncReadOptic } from './Optics/AsyncReadOptic';
-export { GetStateOptions, SubscribeOptions } from './types';
+export { GetStateOptions, SubscribeOptions, GetOpticFocus, GetOpticScope } from './types';

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -1,3 +1,5 @@
+import { tag } from './Optics/ReadOptic';
+
 export type GetStateOptions = {
     denormalize?: boolean;
 };
@@ -5,3 +7,7 @@ export type GetStateOptions = {
 export type SubscribeOptions = {
     denormalize?: boolean;
 };
+
+export type GetOpticFocus<TOptic> = TOptic extends { [tag]: [scope: any, focus: infer T, invariance: any] } ? T : never;
+
+export type GetOpticScope<TOptic> = TOptic extends { [tag]: [scope: infer T, focus: any, invariance: any] } ? T : never;


### PR DESCRIPTION
- Add `GetOpticFocus` to get the type of the focused value from an optic
- Add `GetOpticScope` to get the scope of an optic