### PR TITLE
feat: add For component

### DIFF
--- a/packages/react/src/For.tsx
+++ b/packages/react/src/For.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { GetOpticFocus, GetOpticScope, OpticScope, ReadOptic, Resolve } from '@optics/state';
+import React, { ReactElement, cloneElement, memo } from 'react';
+import { useDeriveOptics } from './useDeriveOptics';
+
+const typedMemo: <T>(c: T) => T = memo;
+
+type Props<TOptic extends ReadOptic<any[], any>, T extends any[], TScope extends OpticScope> = {
+    optic: TOptic;
+    getKey: (t: T[number]) => string;
+    children: (t: Resolve<TOptic, T[number], TScope>, key: string) => ReactElement;
+};
+
+const For = typedMemo(
+    <
+        TOptic extends ReadOptic<any[], any>,
+        T extends any[] = GetOpticFocus<TOptic>,
+        TScope extends OpticScope = GetOpticScope<TOptic>,
+    >({
+        optic,
+        getKey,
+        children,
+    }: Props<TOptic, T, TScope>) => {
+        const optics = useDeriveOptics(optic, getKey);
+
+        return <>{optics.map(([key, optic]) => cloneElement(children(optic, key), { key }))}</>;
+    },
+);
+
+export default For;

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -6,6 +6,7 @@ import { useOptic } from './useOptic';
 import { useOpticReducer } from './useOpticReducer';
 import { pureOptic, PureOptic, Optic, total, createState, ReadOptic } from '@optics/state';
 import { useDeriveOptics } from './useDeriveOptics';
+import For from './For';
 
 describe('useOptic', () => {
     it('should set state', () => {
@@ -141,6 +142,32 @@ describe('useDeriveOptics', () => {
 
         const oddKeys = ['1', '3', '5', '7'];
         expect(oddKeys).toEqual(result.current.map(([key]) => key));
+    });
+    describe('For component', () => {
+        const NumbersWithFor = ({ onArray }: { onArray: Optic<number[]> }) => {
+            const prepend = useCallback(() => {
+                onArray.set((prev) => [prev[0] - 1, ...prev]);
+            }, [onArray]);
+
+            return (
+                <div>
+                    <button onClick={prepend}>prepend</button>
+                    <For optic={onArray} getKey={(n) => n.toString()}>
+                        {(optic) => <Number onNumber={optic} />}
+                    </For>
+                </div>
+            );
+        };
+
+        it('should not rerender the existing cells when prepending', () => {
+            const { getAllByTestId, getByText } = render(<NumbersWithFor onArray={createState([1, 2, 3, 4, 5])} />);
+            const prepend = getByText('prepend');
+            fireEvent.click(prepend);
+            const elems = getAllByTestId('display');
+            const renders = getAllByTestId('renders');
+            expect(elems.map((x) => x.textContent)).toStrictEqual(['0', '1', '2', '3', '4', '5']);
+            expect(renders.map((x) => x.textContent)).toEqual(['1', '1', '1', '1', '1', '1']);
+        });
     });
 });
 describe('useOpticReducer', () => {

--- a/packages/react/src/useDeriveOptics.ts
+++ b/packages/react/src/useDeriveOptics.ts
@@ -1,7 +1,6 @@
-import { GetOpticFocus, GetOpticScope, Lens, OpticScope, ReadOptic, total } from '@optics/state';
+import { GetOpticFocus, GetOpticScope, Lens, OpticScope, ReadOptic, Resolve } from '@optics/state';
 import { useOptic } from './useOptic';
 import { useRef } from 'react';
-import { Resolve } from '@optics/state/src/combinators';
 
 const focusIndex = (index: number): Lens<any, any[]> => ({
     get: (s) => s[index],
@@ -13,7 +12,7 @@ export function useDeriveOptics<
     TOptic extends ReadOptic<any[], any>,
     T extends any[] = GetOpticFocus<TOptic>,
     TScope extends OpticScope = GetOpticScope<TOptic>,
->(onArray: TOptic, getKey: (t: T) => string): [key: string, optic: Resolve<TOptic, T[number], TScope>][] {
+>(onArray: TOptic, getKey: (t: T[number]) => string): [key: string, optic: Resolve<TOptic, T[number], TScope>][] {
     const [array = []] = useOptic(onArray, { denormalize: false });
 
     const cachedOptics = useRef<Record<string, Resolve<TOptic, T[number], TScope>>>({});

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -5,3 +5,4 @@ export { ReadOptic, ResolvedType } from './Optics/ReadOptic';
 export { AsyncOptic } from './Optics/AsyncOptic';
 export { AsyncReadOptic } from './Optics/AsyncReadOptic';
 export { GetStateOptions, SubscribeOptions, GetOpticFocus, GetOpticScope } from './types';
+export { Resolve } from './combinators';


### PR DESCRIPTION
Adds a new `For` react component.
From an optic focused on an array, will derive an optic for every element of the array and call the provided function for each of them.
Keys are used to memoize the optics and are also injected to each React element.

```ts
const arrayOptic = createState([0, 1, 2, 3, 4]);

const Numbers = () => 
  <For optic={arrayOptic} getKey={n => n.toString()}>
    {(numberOptic) => <Number numberOptic={numberOptic} />}
  </For>
```