### PR TITLE
Replace methods by combinator functions

### DIFF
--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -25,17 +25,18 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return set(a, s, this.lenses);
     }
 
-    derive<B>(get: (a: NonNullable<A>) => B): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(get: (a: NonNullable<A>) => B, key?: string): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive<B>(
         get: (a: NonNullable<A>) => B,
         set: (b: B, a: NonNullable<A>) => NonNullable<A>,
+        key?: string,
     ): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive(get: any, set?: any): any {
+    derive(get: any, set?: any, key?: string): any {
         return this.instantiate([
             {
                 get,
                 set: set ?? ((b, a) => a),
-                key: 'derive',
+                key: key ?? 'derive',
                 type: 'unstable',
             },
         ]);

--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -1,21 +1,10 @@
 import CombinatorsImpl from './combinators.impl';
 import { get } from './get';
 import { proxify } from './proxify';
-import { _PureOptic, PureOptic } from './PureOptic';
-import { PureReadOptic, tag } from './PureReadOptic';
+import { _PureOptic } from './PureOptic';
+import { tag } from './PureReadOptic';
 import { set } from './set';
-import {
-    DeriveOpticScope,
-    FocusedValue,
-    FoldLens,
-    FoldNLens,
-    Lens,
-    mapped,
-    OpticScope,
-    partial,
-    PartialLens,
-    TotalLens,
-} from './types';
+import { FocusedValue, Lens, OpticScope } from './types';
 
 class PureOpticImpl<A, TScope extends OpticScope, S>
     extends CombinatorsImpl<A, TScope, S>
@@ -36,12 +25,11 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return set(a, s, this.lenses);
     }
 
-    derive<B>(lens: PartialLens<B, NonNullable<A>>): PureOptic<B, TScope extends partial ? partial : TScope, S>;
-    derive<B>(lens: TotalLens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): PureOptic<A, partial, S>;
-    derive(lens: TScope extends mapped ? FoldNLens<NonNullable<A>> : never): PureOptic<A, mapped, S>;
-    derive({ get, set, key, type }: { get: any; set?: any; key?: string; type?: Lens['type'] }): any {
+    derive(other: any): any {
+        if (other instanceof PureOpticImpl) {
+            return this.instantiate([...other.lenses]);
+        }
+        const { get, set, key, type } = other;
         return this.instantiate([
             {
                 get,

--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -4,7 +4,18 @@ import { proxify } from './proxify';
 import { _PureOptic, PureOptic } from './PureOptic';
 import { PureReadOptic, tag } from './PureReadOptic';
 import { set } from './set';
-import { DeriveOpticScope, FocusedValue, Lens, OpticScope } from './types';
+import {
+    DeriveOpticScope,
+    FocusedValue,
+    FoldLens,
+    FoldNLens,
+    Lens,
+    mapped,
+    OpticScope,
+    partial,
+    PartialLens,
+    TotalLens,
+} from './types';
 
 class PureOpticImpl<A, TScope extends OpticScope, S>
     extends CombinatorsImpl<A, TScope, S>
@@ -25,15 +36,18 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return set(a, s, this.lenses);
     }
 
-    derive<B>(lens: Lens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: PartialLens<B, NonNullable<A>>): PureOptic<B, TScope extends partial ? partial : TScope, S>;
+    derive<B>(lens: TotalLens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive({ get, set, key }: { get: any; set?: any; key?: string }): any {
+    derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): PureOptic<A, partial, S>;
+    derive(lens: TScope extends mapped ? FoldNLens<NonNullable<A>> : never): PureOptic<A, mapped, S>;
+    derive({ get, set, key, type }: { get: any; set?: any; key?: string; type?: Lens['type'] }): any {
         return this.instantiate([
             {
                 get,
                 set: set ?? ((b, a) => a),
                 key: key ?? 'derive',
-                type: 'unstable',
+                type: type ?? 'unstable',
             },
         ]);
     }

--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -40,6 +40,10 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         ]);
     }
 
+    pipe(...fns: ((arg: any) => any)[]) {
+        return fns.reduce((acc, cv) => cv(acc), this);
+    }
+
     protected instantiate(newLenses: Lens[]): any {
         return new PureOpticImpl([...this.lenses, ...newLenses]);
     }

--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -25,13 +25,13 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return set(a, s, this.lenses);
     }
 
-    derive<B>(get: (a: NonNullable<A>) => B, key?: string): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive<B>(
-        get: (a: NonNullable<A>) => B,
-        set: (b: B, a: NonNullable<A>) => NonNullable<A>,
-        key?: string,
-    ): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive(get: any, set?: any, key?: string): any {
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        set: (b: B, a: NonNullable<A>) => NonNullable<A>;
+        key?: string;
+    }): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive({ get, set, key }: { get: any; set?: any; key?: string }): any {
         return this.instantiate([
             {
                 get,

--- a/packages/core/src/PureOptic.impl.ts
+++ b/packages/core/src/PureOptic.impl.ts
@@ -25,11 +25,7 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return set(a, s, this.lenses);
     }
 
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        set: (b: B, a: NonNullable<A>) => NonNullable<A>;
-        key?: string;
-    }): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: Lens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive({ get, set, key }: { get: any; set?: any; key?: string }): any {
         return this.instantiate([
@@ -46,7 +42,7 @@ class PureOpticImpl<A, TScope extends OpticScope, S>
         return new PureOpticImpl([...this.lenses, ...newLenses]);
     }
     private toString(): string {
-        return this.lenses.map((l) => l.key.toString()).toString();
+        return this.lenses.map((l) => l.key ?? 'lens').toString();
     }
 }
 

--- a/packages/core/src/PureOptic.test.ts
+++ b/packages/core/src/PureOptic.test.ts
@@ -95,6 +95,14 @@ describe('derive', () => {
 
         expect(evenNumbersOptic.set((prev) => prev + 10, [1, 2, 3, 4, 5, 6])).toEqual([1, 12, 3, 14, 5, 16]);
     });
+    it('should derive a new optic from another optic', () => {
+        const fooOptic = pureOptic<{ foo: { bar: string } }>();
+        const barOptic = pureOptic<{ bar: string }>();
+        const fooBarOptic = fooOptic.foo.derive(barOptic);
+
+        expect(fooBarOptic.get({ foo: { bar: 'test' } })).toEqual({ bar: 'test' });
+        expect(fooBarOptic.bar.set('fooBar', { foo: { bar: 'test' } })).toEqual({ foo: { bar: 'fooBar' } });
+    });
 });
 describe('derive isomorphism', () => {
     const objectOptic = pureOptic<readonly [string, number]>().derive({

--- a/packages/core/src/PureOptic.test.ts
+++ b/packages/core/src/PureOptic.test.ts
@@ -49,33 +49,30 @@ describe('refine', () => {
 });
 describe('derive', () => {
     it('should derive new read optic from get function', () => {
-        const fooOptic = pureOptic<{ foo: string }>().derive((a) => a.foo);
+        const fooOptic = pureOptic<{ foo: string }>().derive({ get: (a) => a.foo });
         expect(fooOptic.get({ foo: 'test' })).toBe('test');
     });
     it('should derive new optic from a get and a set function', () => {
-        const fooOptic = pureOptic<{ foo: string }>().derive(
-            (a) => a.foo,
-            (b, a) => ({ ...a, foo: b }),
-        );
+        const fooOptic = pureOptic<{ foo: string }>().derive({ get: (a) => a.foo, set: (b, a) => ({ ...a, foo: b }) });
         expect(fooOptic.get({ foo: 'test' })).toBe('test');
         expect(fooOptic.set('newFoo', { foo: 'test' })).toEqual({ foo: 'newFoo' });
     });
 });
 describe('derive', () => {
-    const objectOptic = pureOptic<[string, number]>().derive(
-        ([name, age]) => ({ name, age }),
-        ({ name, age }) => [name, age],
-    );
+    const objectOptic = pureOptic<readonly [string, number]>().derive({
+        get: ([name, age]) => ({ name, age }),
+        set: (p) => [p.name, p.age] as const,
+    });
 
     it('should derive from tuple to object', () => {
         expect(objectOptic.get(['Jean', 42])).toStrictEqual({ name: 'Jean', age: 42 });
         expect(objectOptic.set({ name: 'Albert', age: 65 }, ['Jean', 34])).toStrictEqual(['Albert', 65]);
     });
     it('should derive from celcius to fahrenheit', () => {
-        const tempOptic = pureOptic<number>().derive(
-            (celcius) => celcius * (9 / 5) + 32,
-            (fahrenheit) => (fahrenheit - 32) * (5 / 9),
-        );
+        const tempOptic = pureOptic<number>().derive({
+            get: (celcius) => celcius * (9 / 5) + 32,
+            set: (fahrenheit) => (fahrenheit - 32) * (5 / 9),
+        });
 
         expect(tempOptic.get(0)).toBe(32);
         expect(tempOptic.get(100)).toBe(212);

--- a/packages/core/src/PureOptic.test.ts
+++ b/packages/core/src/PureOptic.test.ts
@@ -125,6 +125,21 @@ describe('derive isomorphism', () => {
         expect(tempOptic.set(212, 0)).toBe(100);
     });
 });
+describe('pipe', () => {
+    it('should pipe unary functions and return the last function result', () => {
+        const endResult = pureOptic<{ foo: { bar: number } }>()
+            .pipe((fooOptic) => fooOptic.foo)
+            .pipe((barOptic) => barOptic.bar)
+            .pipe(
+                (optic) => optic.get({ foo: { bar: 42 } }),
+                (n) => n * 2,
+                (n) => n + 10,
+                (n) => n.toString(),
+                (s) => s.split(''),
+            );
+        expect(endResult).toEqual(['9', '4']);
+    });
+});
 describe('if', () => {
     const evenNumberOptic = pureOptic<number>().if((n) => n % 2 === 0);
 

--- a/packages/core/src/PureOptic.test.ts
+++ b/packages/core/src/PureOptic.test.ts
@@ -338,11 +338,11 @@ describe('entries', () => {
     });
 });
 describe('custom optic', () => {
-    const evenNumsOptic = pureOptic(
-        (s: number[]) => s.filter((n) => n % 2 === 0),
-        (a) => a,
-        'onEven',
-    );
+    const evenNumsOptic = pureOptic<number[]>().derive({
+        get: (s: number[]) => s.filter((n) => n % 2 === 0),
+        set: (a) => a,
+        key: 'evenNums',
+    });
     const nums = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     it('should work', () => {
         expect(evenNumsOptic.get(nums)).toStrictEqual([0, 2, 4, 6, 8]);
@@ -355,11 +355,11 @@ describe('custom optic', () => {
     };
     it('should work', () => {
         const countryOptic = (country: string) =>
-            pureOptic(
-                (s: typeof countryInfos) => s[country],
-                (a, s) => (s[country] !== undefined ? { ...s, [country]: a } : s),
-                'onCountry ' + country,
-            );
+            pureOptic<typeof countryInfos>().derive({
+                get: (s) => s[country],
+                set: (a, s) => (s[country] !== undefined ? { ...s, [country]: a } : s),
+                key: 'optic on ' + country,
+            });
         const franceOptic = countryOptic('france');
         const spainOptic = countryOptic('spain');
 

--- a/packages/core/src/PureOptic.ts
+++ b/packages/core/src/PureOptic.ts
@@ -1,11 +1,9 @@
-import { PureReadOptic, _PureReadOptic } from './PureReadOptic';
+import { _PureReadOptic } from './PureReadOptic';
 import { CombinatorsForOptic } from './combinators.types';
-import { DeriveOpticScope, Lens, OpticScope, total } from './types';
+import { DeriveOpticScope, OpticScope, total } from './types';
 
 export interface _PureOptic<A, TScope extends OpticScope = total, S = any> extends _PureReadOptic<A, TScope, S> {
     set(a: A | ((prev: A) => A), s: S): S;
-    derive<B>(lens: Lens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
 }
 
 type DeriveFromProps<A, TScope extends OpticScope, S, T = NonNullable<A>> = T extends Record<any, any>

--- a/packages/core/src/PureOptic.ts
+++ b/packages/core/src/PureOptic.ts
@@ -4,12 +4,12 @@ import { DeriveOpticScope, OpticScope, total } from './types';
 
 export interface _PureOptic<A, TScope extends OpticScope = total, S = any> extends _PureReadOptic<A, TScope, S> {
     set(a: A | ((prev: A) => A), s: S): S;
-    derive<B>(get: (a: NonNullable<A>) => B, key?: string): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
-    derive<B>(
-        get: (a: NonNullable<A>) => B,
-        set: (b: B, a: NonNullable<A>) => NonNullable<A>,
-        key?: string,
-    ): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        set: (b: B, a: NonNullable<A>) => NonNullable<A>;
+        key?: string;
+    }): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
 }
 
 type DeriveFromProps<A, TScope extends OpticScope, S, T = NonNullable<A>> = T extends Record<any, any>

--- a/packages/core/src/PureOptic.ts
+++ b/packages/core/src/PureOptic.ts
@@ -4,10 +4,11 @@ import { DeriveOpticScope, OpticScope, total } from './types';
 
 export interface _PureOptic<A, TScope extends OpticScope = total, S = any> extends _PureReadOptic<A, TScope, S> {
     set(a: A | ((prev: A) => A), s: S): S;
-    derive<B>(get: (a: NonNullable<A>) => B): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(get: (a: NonNullable<A>) => B, key?: string): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive<B>(
         get: (a: NonNullable<A>) => B,
         set: (b: B, a: NonNullable<A>) => NonNullable<A>,
+        key?: string,
     ): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
 }
 

--- a/packages/core/src/PureOptic.ts
+++ b/packages/core/src/PureOptic.ts
@@ -1,14 +1,10 @@
 import { PureReadOptic, _PureReadOptic } from './PureReadOptic';
 import { CombinatorsForOptic } from './combinators.types';
-import { DeriveOpticScope, OpticScope, total } from './types';
+import { DeriveOpticScope, Lens, OpticScope, total } from './types';
 
 export interface _PureOptic<A, TScope extends OpticScope = total, S = any> extends _PureReadOptic<A, TScope, S> {
     set(a: A | ((prev: A) => A), s: S): S;
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        set: (b: B, a: NonNullable<A>) => NonNullable<A>;
-        key?: string;
-    }): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: Lens<B, NonNullable<A>>): PureOptic<B, DeriveOpticScope<A, TScope>, S>;
     derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
 }
 

--- a/packages/core/src/PureReadOptic.ts
+++ b/packages/core/src/PureReadOptic.ts
@@ -1,5 +1,7 @@
+import { PureOptic } from './PureOptic';
 import { CombinatorsForOptic, Resolve } from './combinators.types';
 import {
+    ComposeScopes,
     DeriveOpticScope,
     FocusedValue,
     FoldLens,
@@ -21,6 +23,12 @@ export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): Resolve<this, A, partial, S>;
     derive(lens: TScope extends mapped ? FoldNLens<NonNullable<A>> : never): Resolve<this, A, mapped, S>;
     derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B, TScopeB extends OpticScope>(
+        other: PureOptic<B, TScopeB, NonNullable<A>>,
+    ): Resolve<this, B, ComposeScopes<TScope, TScopeB, A>, S>;
+    derive<B, TScopeB extends OpticScope>(
+        other: PureReadOptic<B, TScopeB, NonNullable<A>>,
+    ): PureReadOptic<B, ComposeScopes<TScope, TScopeB, A>, S>;
     [tag]: [scope: TScope, root: S, invariance: (a: A, s: S) => void];
 }
 

--- a/packages/core/src/PureReadOptic.ts
+++ b/packages/core/src/PureReadOptic.ts
@@ -18,6 +18,7 @@ export const tag: unique symbol = Symbol('tag');
 
 export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     get(s: S): FocusedValue<A, TScope>;
+
     derive<B>(lens: PartialLens<B, NonNullable<A>>): Resolve<this, B, TScope extends partial ? partial : TScope, S>;
     derive<B>(lens: TotalLens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>, S>;
     derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): Resolve<this, A, partial, S>;
@@ -29,6 +30,69 @@ export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     derive<B, TScopeB extends OpticScope>(
         other: PureReadOptic<B, TScopeB, NonNullable<A>>,
     ): PureReadOptic<B, ComposeScopes<TScope, TScopeB, A>, S>;
+
+    pipe<B>(fn1: (optic: this) => B): B;
+    pipe<B, C>(fn1: (optic: this) => B, fn2: (b: B) => C): C;
+    pipe<B, C, D>(fn1: (optic: this) => B, fn2: (b: B) => C, fn3: (c: C) => D): D;
+    pipe<B, C, D, E>(fn1: (optic: this) => B, fn2: (b: B) => C, fn3: (c: C) => D, fn4: (d: D) => E): E;
+    pipe<B, C, D, E, F>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+    ): F;
+    pipe<B, C, D, E, F, G>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+    ): G;
+    pipe<B, C, D, E, F, G, H>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+    ): H;
+    pipe<B, C, D, E, F, G, H, I>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+    ): I;
+    pipe<B, C, D, E, F, G, H, I, J>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+        fn9: (f: I) => J,
+    ): J;
+    pipe<B, C, D, E, F, G, H, I, J, K>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+        fn9: (f: I) => J,
+        fn10: (f: J) => K,
+    ): K;
+
     [tag]: [scope: TScope, root: S, invariance: (a: A, s: S) => void];
 }
 

--- a/packages/core/src/PureReadOptic.ts
+++ b/packages/core/src/PureReadOptic.ts
@@ -5,7 +5,7 @@ export const tag: unique symbol = Symbol('tag');
 
 export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     get(s: S): FocusedValue<A, TScope>;
-    derive<B>(get: (a: NonNullable<A>) => B): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
+    derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
     [tag]: [scope: TScope, root: S, invariance: (a: A, s: S) => void];
 }
 

--- a/packages/core/src/PureReadOptic.ts
+++ b/packages/core/src/PureReadOptic.ts
@@ -1,10 +1,25 @@
-import { CombinatorsForOptic } from './combinators.types';
-import { DeriveOpticScope, FocusedValue, OpticScope, total } from './types';
+import { CombinatorsForOptic, Resolve } from './combinators.types';
+import {
+    DeriveOpticScope,
+    FocusedValue,
+    FoldLens,
+    FoldNLens,
+    OpticScope,
+    PartialLens,
+    TotalLens,
+    mapped,
+    partial,
+    total,
+} from './types';
 
 export const tag: unique symbol = Symbol('tag');
 
 export interface _PureReadOptic<A, TScope extends OpticScope = total, S = any> {
     get(s: S): FocusedValue<A, TScope>;
+    derive<B>(lens: PartialLens<B, NonNullable<A>>): Resolve<this, B, TScope extends partial ? partial : TScope, S>;
+    derive<B>(lens: TotalLens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>, S>;
+    derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): Resolve<this, A, partial, S>;
+    derive(lens: TScope extends mapped ? FoldNLens<NonNullable<A>> : never): Resolve<this, A, mapped, S>;
     derive<B>(lens: { get: (a: NonNullable<A>) => B; key?: string }): PureReadOptic<B, DeriveOpticScope<A, TScope>, S>;
     [tag]: [scope: TScope, root: S, invariance: (a: A, s: S) => void];
 }

--- a/packages/core/src/combinators.impl.ts
+++ b/packages/core/src/combinators.impl.ts
@@ -6,9 +6,7 @@ import {
     RecordCombinators,
     Resolve,
 } from './combinators.types';
-import { PureOptic } from './PureOptic';
-import { PureReadOptic } from './PureReadOptic';
-import { ComposeScopes, Lens, mapped, OpticScope, partial, ToPartial } from './types';
+import { Lens, mapped, OpticScope, partial, ToPartial } from './types';
 
 abstract class CombinatorsImpl<A, TScope extends OpticScope, S>
     implements
@@ -39,19 +37,6 @@ abstract class CombinatorsImpl<A, TScope extends OpticScope, S>
                 set: (a, s) => (predicate(s) === true ? a : s),
                 key: 'if',
             },
-        ]);
-    }
-
-    compose<B, TScopeB extends OpticScope>(
-        other: PureOptic<B, TScopeB, NonNullable<A>>,
-    ): Resolve<this, B, ComposeScopes<TScope, TScopeB, A>, S>;
-    compose<B, TScopeB extends OpticScope>(
-        other: PureReadOptic<B, TScopeB, NonNullable<A>>,
-    ): PureReadOptic<B, ComposeScopes<TScope, TScopeB, A>, S>;
-    compose(other: any): any {
-        return this.instantiate([
-            { get: (s) => s, set: (a) => a, key: 'compose', type: 'unstable' },
-            ...(other as unknown as this).lenses,
         ]);
     }
 

--- a/packages/core/src/combinators.impl.ts
+++ b/packages/core/src/combinators.impl.ts
@@ -329,7 +329,7 @@ abstract class CombinatorsImpl<A, TScope extends OpticScope, S>
         return this.instantiate([
             {
                 key: 'default',
-                type: 'nullable',
+                type: 'partial',
                 get: (s) => {
                     return s === null || s === undefined ? fallback() : s;
                 },

--- a/packages/core/src/combinators.types.ts
+++ b/packages/core/src/combinators.types.ts
@@ -1,18 +1,12 @@
 import { PureOptic } from './PureOptic';
 import { PureReadOptic } from './PureReadOptic';
-import { ComposeScopes, IsAny, IsNullable, mapped, OpticScope, partial, ToPartial } from './types';
+import { IsAny, IsNullable, mapped, OpticScope, partial, ToPartial } from './types';
 
 export interface BaseCombinators<A, TScope extends OpticScope, S> {
     refine<B>(
         refiner: (a: NonNullable<A>) => B | false,
     ): B extends false ? never : Resolve<this, B, ToPartial<TScope>, S>;
     if(predicate: (a: NonNullable<A>) => boolean): Resolve<this, A, ToPartial<TScope>, S>;
-    compose<B, TScopeB extends OpticScope>(
-        other: PureOptic<B, TScopeB, NonNullable<A>>,
-    ): Resolve<this, B, ComposeScopes<TScope, TScopeB, A>, S>;
-    compose<B, TScopeB extends OpticScope>(
-        other: PureReadOptic<B, TScopeB, NonNullable<A>>,
-    ): PureReadOptic<B, ComposeScopes<TScope, TScopeB, A>, S>;
 }
 
 export interface ArrayCombinators<A, TScope extends OpticScope, S, Elem = A extends (infer R)[] ? R : never> {

--- a/packages/core/src/get.ts
+++ b/packages/core/src/get.ts
@@ -9,7 +9,7 @@ export const get = <A, TScope extends OpticScope>(
 ): FocusedValue<A, TScope> => {
     const aux = (s: any, lenses: Lens[], isTraversal = false): any => {
         const [lens, ...tailLenses] = lenses;
-        if (!lens || ((s === undefined || s === null) && lens.type !== 'nullable')) {
+        if (!lens || ((s === undefined || s === null) && lens.type !== 'partial')) {
             return s;
         }
         const a = earlyReturn?.(s, lens);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,10 @@ export {
     ToPartial,
     FocusedValue,
     DeriveOpticScope,
+    TotalLens,
+    PartialLens,
+    FoldLens,
+    FoldNLens,
 } from './types';
 export { default as CombinatorsImpl } from './combinators.impl';
 export { get } from './get';

--- a/packages/core/src/pureOpticConstructor.ts
+++ b/packages/core/src/pureOpticConstructor.ts
@@ -2,15 +2,6 @@ import PureOpticImpl from './PureOptic.impl';
 import { PureOptic } from './PureOptic';
 import { total } from './types';
 
-export function pureOptic<A, S>(get: (s: S) => A, set: (a: A, s: S) => S, key?: string): PureOptic<A, total, S>;
-export function pureOptic<S>(key?: string): PureOptic<S, total, S>;
-export function pureOptic<A, S>(
-    getOrKey?: string | ((s: S) => A),
-    set?: (a: A, s: S) => S,
-    key?: string,
-): PureOptic<A, total, S> {
-    if (typeof getOrKey === 'function') {
-        return new PureOpticImpl([{ get: getOrKey, set: set as any, key: key ?? 'custom optic' }]) as any;
-    }
-    return new PureOpticImpl([{ get: (s) => s, set: (a) => a, key: getOrKey || 'custom optic' }]) as any;
+export function pureOptic<S>(key?: string): PureOptic<S, total, S> {
+    return new PureOpticImpl([{ get: (s) => s, set: (a) => a, key: key || 'custom optic' }]) as any;
 }

--- a/packages/core/src/set.ts
+++ b/packages/core/src/set.ts
@@ -8,7 +8,7 @@ export const set = <A, S>(a: A | ((prev: A) => A), s: S, lenses: Lens[], foldTre
         return set(a, s, tailLenses);
     }
     const slice = lens.get(s);
-    if ((slice === undefined || slice === null) && tailLenses.length > 0 && tailLenses[0].type !== 'nullable') return s;
+    if ((slice === undefined || slice === null) && tailLenses.length > 0 && tailLenses[0].type !== 'partial') return s;
     if (lens.type === 'map') {
         const newSlice = foldTree
             ? (slice as any[]).map((x, index) => (foldTree[index] ? set(a, x, tailLenses, foldTree[index]) : x))

--- a/packages/core/src/type.test.ts
+++ b/packages/core/src/type.test.ts
@@ -98,33 +98,30 @@ describe('Derived types', () => {
          * PureOptic + get = PureReadOptic
          */
         // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-        expectWritableOptic(() => pureOptic<{ foo: string }>().derive((x) => x.foo));
+        expectWritableOptic(() => pureOptic<{ foo: string }>().derive({ get: (x) => x.foo }));
         /**
          * PureReadOptic + get = PureReadOptic
          */
         expectWritableOptic(() =>
             // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-            (pureOptic<{ foo: string }>() as PureReadOptic<{ foo: string }>).derive((x) => x.foo),
+            (pureOptic<{ foo: string }>() as PureReadOptic<{ foo: string }>).derive({ get: (x) => x.foo }),
         );
 
         /**
          * PureOptic + get & set = PureOptic
          */
         expectWritableOptic(() =>
-            pureOptic<{ foo: string }>().derive(
-                (x) => x.foo,
-                (x, y) => ({ ...y, foo: x }),
-            ),
+            pureOptic<{ foo: string }>().derive({ get: (x) => x.foo, set: (x, y) => ({ ...y, foo: x }) }),
         );
 
         /**
          * PureReadOptic + get & set = ❌
          */
-        (pureOptic<{ foo: string }>() as PureReadOptic<{ foo: string }>).derive(
-            (x) => x.foo,
-            // @ts-expect-error Expected 1 arguments, but got 2.
-            (x, y) => ({ ...y, foo: x }),
-        );
+        (pureOptic<{ foo: string }>() as PureReadOptic<{ foo: string }>).derive({
+            get: (x) => x.foo,
+            // @ts-expect-error set property doesn't exist
+            set: (x, y) => ({ ...y, foo: x }),
+        });
     });
 });
 
@@ -156,8 +153,8 @@ describe('Type relations', () => {
         });
         it('should return a PureReadOptic when calling combinators', () => {
             const stringReadOptic: PureReadOptic<string> = pureOptic<string>();
-            // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-            const numberOptic: PureOptic<number> = stringReadOptic.derive(parseInt, (n) => `${n}`);
+            // @ts-expect-error lens property of derive method doesn't take a set function
+            const numberOptic = stringReadOptic.derive({ get: parseInt, set: (n) => `${n}` });
 
             const numbersReadOptic: PureReadOptic<number[]> = pureOptic<number[]>();
             // @ts-expect-error PureOptic isn't assignable to PureReadOptic

--- a/packages/core/src/type.test.ts
+++ b/packages/core/src/type.test.ts
@@ -16,68 +16,72 @@ describe('Derived types', () => {
         /**
          * total on non nullable + total = total
          */
-        expectTotal(() => pureOptic<{ foo: string }>().foo.compose({} as PureOptic<boolean>));
+        expectTotal(() => pureOptic<{ foo: string }>().foo.derive({} as PureOptic<boolean>));
 
         /**
          * total on nullable + total = partial
          */
         expectPartial(() =>
-            pureOptic<{ foo: string | undefined }>().foo.compose({} as PureOptic<boolean, total, string>),
+            pureOptic<{ foo: string | undefined }>().foo.derive({} as PureOptic<boolean, total, string>),
         );
 
         /**
          * total + partial = partial
          */
-        expectPartial(() => pureOptic<{ foo: string }>().foo.compose({} as PureOptic<boolean, partial>));
+        expectPartial(() => pureOptic<{ foo: string }>().foo.derive({} as PureOptic<boolean, partial, string>));
 
         /**
          * total + mapped = mapped
          */
-        expectMapped(() => pureOptic<{ foo: string[] }>().foo.compose({} as PureOptic<boolean, mapped>));
+        expectMapped(() => pureOptic<{ foo: string[] }>().foo.derive({} as PureOptic<boolean, mapped, string[]>));
 
         /**
          * partial + total = partial
          */
-        expectPartial(() => pureOptic<{ foo?: { bar: string } }>().foo.bar.compose({} as PureOptic<boolean>));
+        expectPartial(() => pureOptic<{ foo?: { bar: string } }>().foo.bar.derive({} as PureOptic<boolean>));
 
         /**
          * partial + partial = partial
          */
-        expectPartial(() => pureOptic<{ foo?: { bar: string } }>().foo.bar.compose({} as PureOptic<boolean, partial>));
+        expectPartial(() =>
+            pureOptic<{ foo?: { bar: string } }>().foo.bar.derive({} as PureOptic<boolean, partial, string>),
+        );
 
         /**
          * partial + mapped = mapped
          */
-        expectMapped(() => pureOptic<{ foo?: { bar: string } }>().foo.bar.compose({} as PureOptic<boolean, mapped>));
+        expectMapped(() =>
+            pureOptic<{ foo?: { bar: string } }>().foo.bar.derive({} as PureOptic<boolean, mapped, string>),
+        );
 
         /**
          * mapped + total = mapped
          */
-        expectMapped(() => (({} as PureOptic<string, mapped>).compose({} as PureOptic<boolean>)));
+        expectMapped(() => (({} as PureOptic<string, mapped>).derive({} as PureOptic<boolean>)));
 
         /**
          * mapped + partial = mapped
          */
-        expectMapped(() => (({} as PureOptic<string, mapped>).compose({} as PureOptic<boolean, partial>)));
+        expectMapped(() => (({} as PureOptic<string, mapped>).derive({} as PureOptic<boolean, partial, string>)));
 
         /**
          * mapped + mapped = mapped
          */
-        expectMapped(() => (({} as PureOptic<string, mapped>).compose({} as PureOptic<boolean, mapped>)));
+        expectMapped(() => (({} as PureOptic<string, mapped>).derive({} as PureOptic<boolean, mapped, string>)));
     });
     describe('Writable status', () => {
         /**
          * PureOptic + PureReadOptic = PureReadOptic
          */
         // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-        expectWritableOptic(() => pureOptic<string>().compose({} as PureReadOptic<string, total, string>));
+        expectWritableOptic(() => pureOptic<string>().derive({} as PureReadOptic<string, total, string>));
 
         /**
          * PureReadOptic + PureOptic = PureReadOptic
          */
         expectWritableOptic(
             // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-            () => (pureOptic<string>() as PureReadOptic<string>).compose({} as PureOptic<string, total, string>),
+            () => (pureOptic<string>() as PureReadOptic<string>).derive({} as PureOptic<string, total, string>),
         );
 
         /**
@@ -85,7 +89,7 @@ describe('Derived types', () => {
          */
         expectWritableOptic(
             // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-            () => (pureOptic<string>() as PureReadOptic<string>).compose({} as PureReadOptic<string, total, string>),
+            () => (pureOptic<string>() as PureReadOptic<string>).derive({} as PureReadOptic<string, total, string>),
         );
 
         /**

--- a/packages/core/src/type.test.ts
+++ b/packages/core/src/type.test.ts
@@ -113,15 +113,6 @@ describe('Derived types', () => {
         expectWritableOptic(() =>
             pureOptic<{ foo: string }>().derive({ get: (x) => x.foo, set: (x, y) => ({ ...y, foo: x }) }),
         );
-
-        /**
-         * PureReadOptic + get & set = ❌
-         */
-        (pureOptic<{ foo: string }>() as PureReadOptic<{ foo: string }>).derive({
-            get: (x) => x.foo,
-            // @ts-expect-error set property doesn't exist
-            set: (x, y) => ({ ...y, foo: x }),
-        });
     });
 });
 
@@ -153,12 +144,10 @@ describe('Type relations', () => {
         });
         it('should return a PureReadOptic when calling combinators', () => {
             const stringReadOptic: PureReadOptic<string> = pureOptic<string>();
-            // @ts-expect-error lens property of derive method doesn't take a set function
-            const numberOptic = stringReadOptic.derive({ get: parseInt, set: (n) => `${n}` });
+            const numberOptic: PureReadOptic<number> = stringReadOptic.derive({ get: parseInt, set: (n) => `${n}` });
 
             const numbersReadOptic: PureReadOptic<number[]> = pureOptic<number[]>();
-            // @ts-expect-error PureOptic isn't assignable to PureReadOptic
-            const firstPositiveOptic: PureOptic<number, partial> = numbersReadOptic.findFirst((n) => n > 0);
+            const firstPositiveOptic: PureReadOptic<number, partial> = numbersReadOptic.findFirst((n) => n > 0);
         });
     });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -19,6 +19,27 @@ export interface Lens<A = any, S = any> {
     type?: 'fold' | 'foldN' | 'map' | 'partial' | 'unstable';
 }
 
+export type TotalLens<A = any, S = any> = Omit<Lens<A, S>, 'type'>;
+
+export interface PartialLens<A = any, S = any> {
+    get: (s: S) => A | undefined;
+    set: (a: A, s: S) => S;
+    type: 'partial';
+    key?: string;
+}
+
+export interface FoldLens<S = any> {
+    get: (s: S[]) => number;
+    type: 'fold';
+    key?: string;
+}
+
+export interface FoldNLens<S = any> {
+    get: (s: S[]) => number[];
+    type: 'foldN';
+    key?: string;
+}
+
 type StrictMode = null extends string ? false : true;
 export type IsNullable<T> = StrictMode extends false
     ? false

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,9 +13,9 @@ export interface mapped {
 export type OpticScope = mapped | partial;
 
 export interface Lens<A = any, S = any> {
-    key: string;
     get: (s: S) => A;
     set: (a: A, s: S) => S;
+    key?: string;
     type?: 'fold' | 'foldN' | 'map' | 'nullable' | 'unstable';
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,7 +16,7 @@ export interface Lens<A = any, S = any> {
     get: (s: S) => A;
     set: (a: A, s: S) => S;
     key?: string;
-    type?: 'fold' | 'foldN' | 'map' | 'nullable' | 'unstable';
+    type?: 'fold' | 'foldN' | 'map' | 'partial' | 'unstable';
 }
 
 type StrictMode = null extends string ? false : true;

--- a/packages/react/src/react.test.tsx
+++ b/packages/react/src/react.test.tsx
@@ -39,14 +39,14 @@ describe('useOptic', () => {
     });
     it('should update state if optic changes', () => {
         const rootOptic = createState({ test: 42 });
-        const timesTwo = rootOptic.derive(
-            (a) => ({
+        const timesTwo = rootOptic.derive({
+            get: (a) => ({
                 test: a.test * 2,
             }),
-            (b) => ({
+            set: (b) => ({
                 test: b.test / 2,
             }),
-        );
+        });
         const { result, rerender } = renderHook(
             ({ initialValue }: { initialValue: typeof rootOptic }) => useOptic(initialValue),
             {

--- a/packages/state/src/Optic.impl.ts
+++ b/packages/state/src/Optic.impl.ts
@@ -123,6 +123,10 @@ class OpticImpl<A, TScope extends OpticScope>
         ]);
     }
 
+    pipe(...fns: ((arg: any) => any)[]) {
+        return fns.reduce((acc, cv) => cv(acc), this);
+    }
+
     protected override instantiate(newLenses: Lens[]): any {
         return new OpticImpl([...this.lenses, ...newLenses], this.initialValue, this.storeId);
     }

--- a/packages/state/src/Optic.impl.ts
+++ b/packages/state/src/Optic.impl.ts
@@ -108,17 +108,18 @@ class OpticImpl<A, TScope extends OpticScope>
         };
     }
 
-    derive<B>(get: (a: NonNullable<A>) => B): ResolveReadOnly<this, DeriveOpticScope<A, TScope>, TScope>;
+    derive<B>(get: (a: NonNullable<A>) => B, key?: string): ResolveReadOnly<this, DeriveOpticScope<A, TScope>, TScope>;
     derive<B>(
         get: (a: NonNullable<A>) => B,
         set: (b: B, prev: NonNullable<A>) => NonNullable<A>,
+        key?: string,
     ): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
-    derive(get: any, set?: any): any {
+    derive(get: any, set?: any, key?: string): any {
         return this.instantiate([
             {
                 get,
                 set: set ?? ((b, a) => a),
-                key: 'derive',
+                key: key ?? 'derive',
                 type: 'unstable',
             },
         ]);

--- a/packages/state/src/Optic.impl.ts
+++ b/packages/state/src/Optic.impl.ts
@@ -108,13 +108,16 @@ class OpticImpl<A, TScope extends OpticScope>
         };
     }
 
-    derive<B>(get: (a: NonNullable<A>) => B, key?: string): ResolveReadOnly<this, DeriveOpticScope<A, TScope>, TScope>;
-    derive<B>(
-        get: (a: NonNullable<A>) => B,
-        set: (b: B, prev: NonNullable<A>) => NonNullable<A>,
-        key?: string,
-    ): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
-    derive(get: any, set?: any, key?: string): any {
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        set: (b: B, prev: NonNullable<A>) => NonNullable<A>;
+        key?: string;
+    }): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        key?: string;
+    }): ResolveReadOnly<this, DeriveOpticScope<A, TScope>, TScope>;
+    derive({ get, set, key }: { get: any; set?: any; key?: string }): any {
         return this.instantiate([
             {
                 get,

--- a/packages/state/src/Optic.impl.ts
+++ b/packages/state/src/Optic.impl.ts
@@ -1,5 +1,5 @@
-import { CombinatorsImpl, get, proxify, set, FocusedValue, Lens, OpticScope, DeriveOpticScope } from '@optics/core';
-import { Resolve, ResolveReadOnly, TotalCombinators } from './combinators';
+import { CombinatorsImpl, get, proxify, set, FocusedValue, Lens, OpticScope } from '@optics/core';
+import { TotalCombinators } from './combinators';
 import { _Optic } from './Optics/Optic';
 import { Denormalized, Dependencies, Dependency, leafSymbol, ResolvedType, tag } from './Optics/ReadOptic';
 import { Store, stores } from './stores';
@@ -108,18 +108,17 @@ class OpticImpl<A, TScope extends OpticScope>
         };
     }
 
-    derive<B>(lens: Lens<B, NonNullable<A>>): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        key?: string;
-    }): ResolveReadOnly<this, DeriveOpticScope<A, TScope>, TScope>;
-    derive({ get, set, key }: { get: any; set?: any; key?: string }): any {
+    derive(other: any): any {
+        if (Array.isArray(other.lenses)) {
+            return this.instantiate([...other.lenses]);
+        }
+        const { get, set, key, type } = other;
         return this.instantiate([
             {
                 get,
                 set: set ?? ((b, a) => a),
                 key: key ?? 'derive',
-                type: 'unstable',
+                type: type ?? 'unstable',
             },
         ]);
     }

--- a/packages/state/src/Optic.impl.ts
+++ b/packages/state/src/Optic.impl.ts
@@ -108,11 +108,7 @@ class OpticImpl<A, TScope extends OpticScope>
         };
     }
 
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        set: (b: B, prev: NonNullable<A>) => NonNullable<A>;
-        key?: string;
-    }): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
+    derive<B>(lens: Lens<B, NonNullable<A>>): Resolve<this, DeriveOpticScope<A, TScope>, TScope>;
     derive<B>(lens: {
         get: (a: NonNullable<A>) => B;
         key?: string;

--- a/packages/state/src/Optic.test.ts
+++ b/packages/state/src/Optic.test.ts
@@ -82,30 +82,44 @@ describe('Optic', () => {
         expect(listener).toHaveBeenCalledTimes(1);
         expect(listener).toHaveBeenCalledWith(42);
     });
-    describe('combinators', () => {
-        describe('derive', () => {
-            it('should compose with PureOptic', () => {
-                const stateOptic = createState({ a: { b: 42 } });
-                const numberOptic = pureOptic<{ b: number }>().b;
-                const numberFromStateOptic = stateOptic.a.derive(numberOptic);
-                expect(numberFromStateOptic.get()).toBe(42);
-                numberFromStateOptic.set(100);
-                expect(stateOptic.get()).toEqual({ a: { b: 100 } });
-            });
-            it('should derive read only optic from get', () => {
-                const stateOptic = createState({ a: { b: 42 } });
-                const numberOptic = stateOptic.a.derive({ get: (x) => x.b });
-                expect(numberOptic.get()).toBe(42);
-            });
-            it('should derive an optic from get and set', () => {
-                const stateOptic = createState({ a: { b: 42 } });
-                const numberOptic = stateOptic.a.derive({ get: (x) => x.b, set: (b, x) => ({ ...x, b }) });
-                expect(numberOptic.get()).toBe(42);
-                numberOptic.set(100);
-                expect(stateOptic.get()).toEqual({ a: { b: 100 } });
-            });
+    describe('derive', () => {
+        it('should compose with PureOptic', () => {
+            const stateOptic = createState({ a: { b: 42 } });
+            const numberOptic = pureOptic<{ b: number }>().b;
+            const numberFromStateOptic = stateOptic.a.derive(numberOptic);
+            expect(numberFromStateOptic.get()).toBe(42);
+            numberFromStateOptic.set(100);
+            expect(stateOptic.get()).toEqual({ a: { b: 100 } });
+        });
+        it('should derive read only optic from get', () => {
+            const stateOptic = createState({ a: { b: 42 } });
+            const numberOptic = stateOptic.a.derive({ get: (x) => x.b });
+            expect(numberOptic.get()).toBe(42);
+        });
+        it('should derive an optic from get and set', () => {
+            const stateOptic = createState({ a: { b: 42 } });
+            const numberOptic = stateOptic.a.derive({ get: (x) => x.b, set: (b, x) => ({ ...x, b }) });
+            expect(numberOptic.get()).toBe(42);
+            numberOptic.set(100);
+            expect(stateOptic.get()).toEqual({ a: { b: 100 } });
         });
     });
+    describe('pipe', () => {
+        it('should pipe unary functions and return the last function result', () => {
+            const endResult = createState({ foo: { bar: 42 } })
+                .pipe((fooOptic) => fooOptic.foo)
+                .pipe((barOptic) => barOptic.bar)
+                .pipe(
+                    (optic) => optic.get(),
+                    (n) => n * 2,
+                    (n) => n + 10,
+                    (n) => n.toString(),
+                    (s) => s.split(''),
+                );
+            expect(endResult).toEqual(['9', '4']);
+        });
+    });
+
     describe('references', () => {
         const countriesOptic = createState([
             { name: 'Italia', language: 'Italiano' },

--- a/packages/state/src/Optic.test.ts
+++ b/packages/state/src/Optic.test.ts
@@ -58,16 +58,13 @@ describe('Optic', () => {
         });
         it('should return a read only optic when derived with get function', () => {
             const stateOptic = createState({ a: { b: 42 } });
-            const numberOptic = stateOptic.a.derive((x) => x.b);
+            const numberOptic = stateOptic.a.derive({ get: (x) => x.b });
             // @ts-expect-error ReadOptic isn't assignable to Optic
             expectType<Optic<number>>(numberOptic);
         });
         it('should return an optic when derived with get and set function', () => {
             const stateOptic = createState({ a: { b: 42 } });
-            const numberOptic = stateOptic.a.derive(
-                (x) => x.b,
-                (b, x) => ({ ...x, b }),
-            );
+            const numberOptic = stateOptic.a.derive({ get: (x) => x.b, set: (b, x) => ({ ...x, b }) });
             expectType<Optic<number>>(numberOptic);
         });
     });
@@ -99,15 +96,12 @@ describe('Optic', () => {
         describe('derive', () => {
             it('should derive read only optic from get', () => {
                 const stateOptic = createState({ a: { b: 42 } });
-                const numberOptic = stateOptic.a.derive((x) => x.b);
+                const numberOptic = stateOptic.a.derive({ get: (x) => x.b });
                 expect(numberOptic.get()).toBe(42);
             });
             it('should derive an optic from get and set', () => {
                 const stateOptic = createState({ a: { b: 42 } });
-                const numberOptic = stateOptic.a.derive(
-                    (x) => x.b,
-                    (b, x) => ({ ...x, b }),
-                );
+                const numberOptic = stateOptic.a.derive({ get: (x) => x.b, set: (b, x) => ({ ...x, b }) });
                 expect(numberOptic.get()).toBe(42);
                 numberOptic.set(100);
                 expect(stateOptic.get()).toEqual({ a: { b: 100 } });
@@ -387,10 +381,10 @@ describe('Optic', () => {
         });
         it('derive', () => {
             const stateOptic = createState({ obj: { b1: true, b2: false }, a: 42 });
-            const tupleOptic = stateOptic.obj.derive(
-                ({ b1, b2 }) => [b1, b2] as const,
-                ([b1, b2]) => ({ b1, b2 }),
-            );
+            const tupleOptic = stateOptic.obj.derive({
+                get: ({ b1, b2 }) => [b1, b2] as const,
+                set: ([b1, b2]) => ({ b1, b2 }),
+            });
             const tuple = tupleOptic.get();
 
             stateOptic.a.set((prev) => prev + 1);

--- a/packages/state/src/Optics/ReadOptic.ts
+++ b/packages/state/src/Optics/ReadOptic.ts
@@ -1,6 +1,20 @@
-import { OpticScope, total, DeriveOpticScope, FocusedValue } from '@optics/core';
+import {
+    OpticScope,
+    total,
+    DeriveOpticScope,
+    FocusedValue,
+    PartialLens,
+    TotalLens,
+    partial,
+    mapped,
+    FoldLens,
+    FoldNLens,
+    ComposeScopes,
+    PureOptic,
+    PureReadOptic,
+} from '@optics/core';
 import { CombinatorsForOptic } from '../combinators';
-import { GetStateOptions, SubscribeOptions } from '../types';
+import { GetStateOptions, Resolve, ResolveReadOnly, SubscribeOptions } from '../types';
 
 export const tag: unique symbol = Symbol('tag');
 
@@ -55,6 +69,21 @@ export interface _ReadOptic<A, TScope extends OpticScope> {
         listener: (a: ResolvedType<A, TScope, TOptions>) => void,
         options?: TOptions,
     ): () => void;
+    derive<B>(lens: PartialLens<B, NonNullable<A>>): Resolve<this, B, TScope extends partial ? partial : TScope>;
+    derive<B>(lens: TotalLens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>>;
+    derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): Resolve<this, A, partial>;
+    derive(lens: TScope extends mapped ? FoldNLens<NonNullable<A>> : never): Resolve<this, A, mapped>;
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        key?: string;
+    }): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
+    derive<B, TScopeB extends OpticScope>(
+        other: PureOptic<B, TScopeB, NonNullable<A>>,
+    ): Resolve<this, B, ComposeScopes<TScope, TScopeB, A>>;
+    derive<B, TScopeB extends OpticScope>(
+        other: PureReadOptic<B, TScopeB, NonNullable<A>>,
+    ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
+
     [tag]: [scope: TScope, focus: A, invariance: (a: A) => void];
 }
 

--- a/packages/state/src/Optics/ReadOptic.ts
+++ b/packages/state/src/Optics/ReadOptic.ts
@@ -69,6 +69,7 @@ export interface _ReadOptic<A, TScope extends OpticScope> {
         listener: (a: ResolvedType<A, TScope, TOptions>) => void,
         options?: TOptions,
     ): () => void;
+
     derive<B>(lens: PartialLens<B, NonNullable<A>>): Resolve<this, B, TScope extends partial ? partial : TScope>;
     derive<B>(lens: TotalLens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>>;
     derive(lens: TScope extends mapped ? FoldLens<NonNullable<A>> : never): Resolve<this, A, partial>;
@@ -83,6 +84,68 @@ export interface _ReadOptic<A, TScope extends OpticScope> {
     derive<B, TScopeB extends OpticScope>(
         other: PureReadOptic<B, TScopeB, NonNullable<A>>,
     ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
+
+    pipe<B>(fn1: (optic: this) => B): B;
+    pipe<B, C>(fn1: (optic: this) => B, fn2: (b: B) => C): C;
+    pipe<B, C, D>(fn1: (optic: this) => B, fn2: (b: B) => C, fn3: (c: C) => D): D;
+    pipe<B, C, D, E>(fn1: (optic: this) => B, fn2: (b: B) => C, fn3: (c: C) => D, fn4: (d: D) => E): E;
+    pipe<B, C, D, E, F>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+    ): F;
+    pipe<B, C, D, E, F, G>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+    ): G;
+    pipe<B, C, D, E, F, G, H>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+    ): H;
+    pipe<B, C, D, E, F, G, H, I>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+    ): I;
+    pipe<B, C, D, E, F, G, H, I, J>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+        fn9: (f: I) => J,
+    ): J;
+    pipe<B, C, D, E, F, G, H, I, J, K>(
+        fn1: (optic: this) => B,
+        fn2: (b: B) => C,
+        fn3: (c: C) => D,
+        fn4: (d: D) => E,
+        fn5: (e: E) => F,
+        fn6: (f: F) => G,
+        fn7: (f: G) => H,
+        fn8: (f: H) => I,
+        fn9: (f: I) => J,
+        fn10: (f: J) => K,
+    ): K;
 
     [tag]: [scope: TScope, focus: A, invariance: (a: A) => void];
 }

--- a/packages/state/src/combinators.ts
+++ b/packages/state/src/combinators.ts
@@ -10,6 +10,7 @@ import {
     ToPartial,
     PureReadOptic,
     DeriveOpticScope,
+    Lens,
 } from '@optics/core';
 import { AsyncOptic } from './Optics/AsyncOptic';
 import { AsyncReadOptic } from './Optics/AsyncReadOptic';
@@ -25,11 +26,7 @@ export interface BaseCombinators<A, TScope extends OpticScope> {
     compose<B, TScopeB extends OpticScope>(
         other: PureReadOptic<B, TScopeB, NonNullable<A>>,
     ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        set: (b: B, prev: NonNullable<A>) => NonNullable<A>;
-        key?: string;
-    }): Resolve<this, B, DeriveOpticScope<A, TScope>>;
+    derive<B>(lens: Lens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>>;
     derive<B>(lens: {
         get: (a: NonNullable<A>) => B;
         key?: string;

--- a/packages/state/src/combinators.ts
+++ b/packages/state/src/combinators.ts
@@ -25,12 +25,15 @@ export interface BaseCombinators<A, TScope extends OpticScope> {
     compose<B, TScopeB extends OpticScope>(
         other: PureReadOptic<B, TScopeB, NonNullable<A>>,
     ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
-    derive<B>(get: (a: NonNullable<A>) => B, key?: string): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
-    derive<B>(
-        get: (a: NonNullable<A>) => B,
-        set: (b: B, prev: NonNullable<A>) => NonNullable<A>,
-        key?: string,
-    ): Resolve<this, B, DeriveOpticScope<A, TScope>>;
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        set: (b: B, prev: NonNullable<A>) => NonNullable<A>;
+        key?: string;
+    }): Resolve<this, B, DeriveOpticScope<A, TScope>>;
+    derive<B>(lens: {
+        get: (a: NonNullable<A>) => B;
+        key?: string;
+    }): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
 }
 
 export interface TotalCombinators {

--- a/packages/state/src/combinators.ts
+++ b/packages/state/src/combinators.ts
@@ -25,10 +25,11 @@ export interface BaseCombinators<A, TScope extends OpticScope> {
     compose<B, TScopeB extends OpticScope>(
         other: PureReadOptic<B, TScopeB, NonNullable<A>>,
     ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
-    derive<B>(get: (a: NonNullable<A>) => B): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
+    derive<B>(get: (a: NonNullable<A>) => B, key?: string): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
     derive<B>(
         get: (a: NonNullable<A>) => B,
         set: (b: B, prev: NonNullable<A>) => NonNullable<A>,
+        key?: string,
     ): Resolve<this, B, DeriveOpticScope<A, TScope>>;
 }
 

--- a/packages/state/src/combinators.ts
+++ b/packages/state/src/combinators.ts
@@ -1,17 +1,4 @@
-import {
-    OpticScope,
-    PureOptic,
-    mapped,
-    partial,
-    total,
-    ComposeScopes,
-    IsAny,
-    IsNullable,
-    ToPartial,
-    PureReadOptic,
-    DeriveOpticScope,
-    Lens,
-} from '@optics/core';
+import { OpticScope, mapped, partial, total, IsAny, IsNullable, ToPartial } from '@optics/core';
 import { AsyncOptic } from './Optics/AsyncOptic';
 import { AsyncReadOptic } from './Optics/AsyncReadOptic';
 import { Optic } from './Optics/Optic';
@@ -20,17 +7,6 @@ import { ReadOptic } from './Optics/ReadOptic';
 export interface BaseCombinators<A, TScope extends OpticScope> {
     refine<B>(refiner: (a: NonNullable<A>) => B | false): B extends false ? never : Resolve<this, B, ToPartial<TScope>>;
     if(predicate: (a: NonNullable<A>) => boolean): Resolve<this, A, ToPartial<TScope>>;
-    compose<B, TScopeB extends OpticScope>(
-        other: PureOptic<B, TScopeB, NonNullable<A>>,
-    ): Resolve<this, B, ComposeScopes<TScope, TScopeB, A>>;
-    compose<B, TScopeB extends OpticScope>(
-        other: PureReadOptic<B, TScopeB, NonNullable<A>>,
-    ): ResolveReadOnly<this, B, ComposeScopes<TScope, TScopeB, A>>;
-    derive<B>(lens: Lens<B, NonNullable<A>>): Resolve<this, B, DeriveOpticScope<A, TScope>>;
-    derive<B>(lens: {
-        get: (a: NonNullable<A>) => B;
-        key?: string;
-    }): ResolveReadOnly<this, B, DeriveOpticScope<A, TScope>>;
 }
 
 export interface TotalCombinators {

--- a/packages/state/src/types.ts
+++ b/packages/state/src/types.ts
@@ -1,4 +1,8 @@
-import { tag } from './Optics/ReadOptic';
+import { OpticScope } from '@optics/core';
+import { ReadOptic, tag } from './Optics/ReadOptic';
+import { AsyncOptic } from './Optics/AsyncOptic';
+import { AsyncReadOptic } from './Optics/AsyncReadOptic';
+import { Optic } from './Optics/Optic';
 
 export type GetStateOptions = {
     denormalize?: boolean;
@@ -11,3 +15,17 @@ export type SubscribeOptions = {
 export type GetOpticFocus<TOptic> = TOptic extends { [tag]: [scope: any, focus: infer T, invariance: any] } ? T : never;
 
 export type GetOpticScope<TOptic> = TOptic extends { [tag]: [scope: infer T, focus: any, invariance: any] } ? T : never;
+
+export type Resolve<TOptic, A, TScope extends OpticScope> = [TOptic] extends [{ setAsync(a: any): any }]
+    ? AsyncOptic<A, TScope>
+    : [TOptic] extends [{ getAsync(): any }]
+    ? AsyncReadOptic<A, TScope>
+    : [TOptic] extends [{ set(a: any): any }]
+    ? Optic<A, TScope>
+    : ReadOptic<A, TScope>;
+
+export type ResolveReadOnly<TOptic, A, TScope extends OpticScope> = [TOptic] extends [
+    { setAsync(a: any): any } | { getAsync(): any },
+]
+    ? AsyncReadOptic<A, TScope>
+    : ReadOptic<A, TScope>;


### PR DESCRIPTION
- Add new overloads of `derive` to accept different type of lenses (partial, total, fold, ...) as well as `PureOptic` and `PureReadOptic`, effectively replacing the `compose` method.

```
optic.derive({ get, set }) --> Optic
optic.derive({ get }) => --> ReadOptic

optic.derive(pureOptic) --> Optic
optic.derive(pureReadOptic) --> ReadOptic
```

#

- Add a new `pipe` method for left-to-right function composition (same as in lodash/fs, effect-ts, ramda, ...).

```ts
const array = numberOptic.pipe(
  optic => optic.get(),
  n => n * 2,
  n => n.toString(),
  s => s.split('')
)
```

Will allow us to later remove the combinators methods (map, refine, findFirst, ...) to turn them into curried functions.