### PR TITLE
Guards and control flow

### DIFF
--- a/packages/react/src/For.tsx
+++ b/packages/react/src/For.tsx
@@ -1,18 +1,7 @@
 'use client';
 
-import {
-    GetOpticFocus,
-    GetOpticScope,
-    OpticScope,
-    ReadOptic,
-    Resolve,
-    opticsFromKey,
-    opticsFromKeyMapped,
-    mapped,
-    partial,
-    total,
-} from '@optics/state';
-import React, { ReactElement, cloneElement, memo, useMemo } from 'react';
+import { GetOpticFocus, GetOpticScope, OpticScope, ReadOptic, Resolve, mapped, partial, total } from '@optics/state';
+import React, { ReactElement, cloneElement, memo } from 'react';
 import { useOptic } from './useOptic';
 
 const typedMemo: <T>(c: T) => T = memo;
@@ -41,19 +30,13 @@ function _For<
 ): JSX.Element {
     const { optic, mappedOptic, getKey, children } = params as any;
 
-    const deriveOptics = useMemo(
-        () =>
-            mappedOptic
-                ? opticsFromKeyMapped<ReadOptic<any, mapped>>({ optic: mappedOptic, getKey: getKey })
-                : opticsFromKey<ReadOptic<any[], partial>>({ optic, getKey: getKey }),
-        [mappedOptic, optic],
-    );
+    const [, { getOptics, getOpticsFromMapping }] = useOptic((mappedOptic ?? optic) as ReadOptic<any[], mapped>, {
+        denormalize: false,
+    });
 
-    useOptic(mappedOptic ?? optic, { denormalize: false });
+    const deriveOptics = getOptics ?? getOpticsFromMapping;
 
-    const derivedOptics = deriveOptics();
-
-    return <>{derivedOptics.map(([key, optic]) => cloneElement(children(optic, key), { key }))}</>;
+    return <>{deriveOptics(getKey).map(([key, optic]) => cloneElement(children(optic, key), { key }))}</>;
 }
 
 export const For = typedMemo(_For);

--- a/packages/react/src/__tests__/useOptic.test-d.ts
+++ b/packages/react/src/__tests__/useOptic.test-d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import { AsyncOptic, AsyncReadOptic, Optic, PureOptic, ReadOptic, mapped, partial } from '@optics/state';
-import { expectType } from 'tsd';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 import { Dispatch, SetStateAction } from 'react';
 import { useOptic } from '../useOptic';
 
@@ -10,8 +10,8 @@ describe('optic type', () => {
         expectType<[number, { setState: Dispatch<SetStateAction<number>> }]>(useOptic({} as AsyncOptic<number>));
     });
     it('should return only the value for read optics', () => {
-        expectType<[number]>(useOptic({} as ReadOptic<number>));
-        expectType<[number]>(useOptic({} as AsyncReadOptic<number>));
+        expectType<[number, {}]>(useOptic({} as ReadOptic<number>));
+        expectType<[number, {}]>(useOptic({} as AsyncReadOptic<number>));
     });
     it("shouldn't accept non stateful optics", () => {
         // @ts-expect-error
@@ -26,7 +26,34 @@ describe('optic scope', () => {
         );
     });
     it('should return an array for mapped optic', () => {
-        expectType<[number[], { setState: Dispatch<SetStateAction<number>> }]>(useOptic({} as Optic<number, mapped>));
+        expectAssignable<[number[], { setState: Dispatch<SetStateAction<number>> }]>(
+            useOptic({} as Optic<number, mapped>),
+        );
+    });
+});
+
+describe('getOptics', () => {
+    it('should return the getOptic function when the focused type is an array', () => {
+        expectAssignable<{ getOptics: (getKey: (t: number) => string) => readonly [string, Optic<number>][] }>(
+            useOptic({} as Optic<number[]>)[1],
+        );
+        expectNotAssignable<{ getOptics: (getKey: (t: number) => string) => readonly [string, Optic<number>][] }>(
+            useOptic({} as Optic<number>)[1],
+        );
+    });
+    it('should return the getOpticFromMapping function when the optic is mapped', () => {
+        expectAssignable<{
+            getOpticsFromMapping: (getKey: (t: number) => string) => readonly [string, Optic<number>][];
+        }>(useOptic({} as Optic<number, mapped>)[1]);
+        expectNotAssignable<{
+            getOpticsFromMapping: (getKey: (t: number) => string) => readonly [string, Optic<number>][];
+        }>(useOptic({} as Optic<number>)[1]);
+    });
+    it('should return both functions when the optic is mapped and the focused type is an array', () => {
+        expectAssignable<{
+            getOptics: (getKey: (t: number) => string) => readonly [string, Optic<number>][];
+            getOpticsFromMapping: (getKey: (t: number[]) => string) => readonly [string, Optic<number[]>][];
+        }>(useOptic({} as Optic<number[], mapped>)[1]);
     });
 });
 

--- a/packages/react/src/__tests__/useOptic.test-d.ts
+++ b/packages/react/src/__tests__/useOptic.test-d.ts
@@ -1,13 +1,13 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { AsyncOptic, AsyncReadOptic, Optic, PureOptic, ReadOptic, mapped, partial, total } from '@optics/state';
+import { AsyncOptic, AsyncReadOptic, Optic, PureOptic, ReadOptic, mapped, partial } from '@optics/state';
 import { expectType } from 'tsd';
 import { Dispatch, SetStateAction } from 'react';
 import { useOptic } from '../useOptic';
 
 describe('optic type', () => {
     it('should return the value and a setter for write optics', () => {
-        expectType<[number, Dispatch<SetStateAction<number>>]>(useOptic({} as Optic<number>));
-        expectType<[number, Dispatch<SetStateAction<number>>]>(useOptic({} as AsyncOptic<number>));
+        expectType<[number, { setState: Dispatch<SetStateAction<number>> }]>(useOptic({} as Optic<number>));
+        expectType<[number, { setState: Dispatch<SetStateAction<number>> }]>(useOptic({} as AsyncOptic<number>));
     });
     it('should return only the value for read optics', () => {
         expectType<[number]>(useOptic({} as ReadOptic<number>));
@@ -21,24 +21,30 @@ describe('optic type', () => {
 
 describe('optic scope', () => {
     it('should return a nullable value for partial optic', () => {
-        expectType<[number | undefined, Dispatch<SetStateAction<number>>]>(useOptic({} as Optic<number, partial>));
+        expectType<[number | undefined, { setState: Dispatch<SetStateAction<number>> }]>(
+            useOptic({} as Optic<number, partial>),
+        );
     });
     it('should return an array for mapped optic', () => {
-        expectType<[number[], Dispatch<SetStateAction<number>>]>(useOptic({} as Optic<number, mapped>));
+        expectType<[number[], { setState: Dispatch<SetStateAction<number>> }]>(useOptic({} as Optic<number, mapped>));
     });
 });
 
 describe('references', () => {
     type StateWithRef = { a: Optic<{ b: number }> };
     it("should return the normalized value if denormalized isn't explicitly set to true", () => {
-        expectType<[StateWithRef, Dispatch<SetStateAction<StateWithRef>>]>(useOptic({} as Optic<StateWithRef>));
-        expectType<[StateWithRef, Dispatch<SetStateAction<StateWithRef>>]>(useOptic({} as Optic<StateWithRef>, {}));
-        expectType<[StateWithRef, Dispatch<SetStateAction<StateWithRef>>]>(
+        expectType<[StateWithRef, { setState: Dispatch<SetStateAction<StateWithRef>> }]>(
+            useOptic({} as Optic<StateWithRef>),
+        );
+        expectType<[StateWithRef, { setState: Dispatch<SetStateAction<StateWithRef>> }]>(
+            useOptic({} as Optic<StateWithRef>, {}),
+        );
+        expectType<[StateWithRef, { setState: Dispatch<SetStateAction<StateWithRef>> }]>(
             useOptic({} as Optic<StateWithRef>, { denormalize: false }),
         );
     });
     it('should return the denormalized value if denormalized is explicitly set to true', () => {
-        expectType<[{ a: { b: number } }, Dispatch<SetStateAction<StateWithRef>>]>(
+        expectType<[{ a: { b: number } }, { setState: Dispatch<SetStateAction<StateWithRef>> }]>(
             useOptic({} as Optic<StateWithRef>, { denormalize: true }),
         );
     });

--- a/packages/react/src/__tests__/useOptic.test.tsx
+++ b/packages/react/src/__tests__/useOptic.test.tsx
@@ -12,6 +12,7 @@ describe('useOptic', () => {
         act(() => result.current[1].setState((prev) => ({ test: prev.test * 2 })));
         expect(result.current[0]).toStrictEqual({ test: 84 });
     });
+
     it('should return referentially stable state and setter', () => {
         const rootOptic = createState({ test: 42 });
         const { result, rerender } = renderHook(() => useOptic(rootOptic));
@@ -21,6 +22,7 @@ describe('useOptic', () => {
         expect(prevState).toBe(state);
         expect(prevSetState).toBe(setState);
     });
+
     it('should not rerender when calling setter with the same reference', () => {
         const rootOptic = createState({ test: 42 });
         const { result } = renderHook(() => useOptic(rootOptic));
@@ -48,6 +50,7 @@ describe('useOptic', () => {
         rerender({ initialValue: timesTwo });
         expect(result.current[0]).toEqual({ test: 84 });
     });
+
     it('should not exhibit the zombie child problem', async () => {
         const stateOptic = createState<number[]>([42]);
         const firstOptic = stateOptic[0];
@@ -64,6 +67,7 @@ describe('useOptic', () => {
         render(<Parent />);
         await act(() => stateOptic.set([]));
     });
+
     describe('references', () => {
         const contactOptic = createState({ phone: '+33**', mail: 'foo@bar.com' });
         const stateOptic = createState({ name: 'foobar', contact: contactOptic });
@@ -72,11 +76,13 @@ describe('useOptic', () => {
             const { result } = renderHook(() => useOptic(stateOptic, { denormalize: true }));
             expect(result.current[0]).toEqual({ name: 'foobar', contact: { phone: '+33**', mail: 'foo@bar.com' } });
         });
+
         it("should't denormalize by default", () => {
             const { result } = renderHook(() => useOptic(stateOptic));
             expect(result.current[0]).toEqual({ name: 'foobar', contact: contactOptic });
         });
     });
+
     describe('getOptics', () => {
         it('should return referentially stable optics', () => {
             const usersOptic = createState([{ name: 'John' }, { name: 'Jeanne' }, { name: 'Vincent' }]);
@@ -90,6 +96,7 @@ describe('useOptic', () => {
             userOptics.forEach(([, optic], index) => expect(optic).toBe(newUserOptics[index + 1][1]));
         });
     });
+
     describe('getOpticsFromMapping', () => {
         it('should return referentially stable optics', () => {
             const stateOptic = createState([
@@ -105,6 +112,71 @@ describe('useOptic', () => {
 
             const newUserOptics = getOpticsFromMapping((user) => user.name);
             userOptics.forEach(([, optic], index) => expect(optic).toBe(newUserOptics[index + 1][1]));
+        });
+    });
+
+    describe('hasValue', () => {
+        const stateOptic = createState<{ name: string; contact?: { mail: string | undefined } }>({
+            name: 'foobar',
+            contact: { mail: 'foo@bar.com' },
+        });
+        const mailOptic = stateOptic.contact.mail;
+        const useHasValue = () => {
+            const [, { hasValue }] = useOptic(mailOptic);
+            return hasValue((optic) => optic);
+        };
+
+        beforeEach(() => {
+            stateOptic.set({
+                name: 'foobar',
+                contact: { mail: 'foo@bar.com' },
+            });
+        });
+
+        it('should provide to the callback the same optic as the one passed to useOptic', () => {
+            const { result } = renderHook(() => useHasValue());
+            expect(result.current).toBe(mailOptic);
+        });
+
+        it('should return null if the optic has no value', () => {
+            const { result } = renderHook(() => useHasValue());
+            expect(result.current).not.toBe(null);
+            act(() => stateOptic.set({ name: 'foobar' }));
+            expect(result.current).toBe(null);
+        });
+
+        it('should return null if the focused value is undefined', () => {
+            const { result } = renderHook(() => useHasValue());
+            expect(result.current).not.toBe(null);
+            act(() => mailOptic.set(undefined));
+            expect(result.current).toBe(null);
+        });
+    });
+    describe('guard', () => {
+        type A = {
+            type: 'a';
+            a: number;
+        };
+        type B = {
+            type: 'b';
+            b: string;
+        };
+        type Union = A | B;
+
+        const unionOptic = createState<Union>({ type: 'a', a: 42 });
+
+        beforeEach(() => {
+            unionOptic.set({ type: 'a', a: 42 });
+        });
+
+        it('should provide to the callback the same optic as the one passed to useOptic', () => {
+            const { guard } = renderHook(() => useOptic(unionOptic)).result.current[1];
+            guard((union) => union.type === 'a' && union)((optic) => expect(optic).toBe(unionOptic));
+        });
+
+        it('should return null if the guard is not satisfied', () => {
+            const { guard } = renderHook(() => useOptic(unionOptic)).result.current[1];
+            expect(guard((union) => union.type === 'b' && union)(() => 'success')).toBeNull();
         });
     });
 });

--- a/packages/react/src/__tests__/useOptic.test.tsx
+++ b/packages/react/src/__tests__/useOptic.test.tsx
@@ -9,15 +9,15 @@ describe('useOptic', () => {
     it('should set state', () => {
         const rootOptic = createState({ test: 42 });
         const { result } = renderHook(() => useOptic(rootOptic));
-        act(() => result.current[1]((prev) => ({ test: prev.test * 2 })));
+        act(() => result.current[1].setState((prev) => ({ test: prev.test * 2 })));
         expect(result.current[0]).toStrictEqual({ test: 84 });
     });
     it('should return referentially stable state and setter', () => {
         const rootOptic = createState({ test: 42 });
         const { result, rerender } = renderHook(() => useOptic(rootOptic));
-        const [prevState, prevSetState] = result.current;
+        const [prevState, { setState: prevSetState }] = result.current;
         rerender();
-        const [state, setState] = result.current;
+        const [state, { setState }] = result.current;
         expect(prevState).toBe(state);
         expect(prevSetState).toBe(setState);
     });
@@ -25,7 +25,7 @@ describe('useOptic', () => {
         const rootOptic = createState({ test: 42 });
         const { result } = renderHook(() => useOptic(rootOptic));
         const initialResult = result.current;
-        act(() => initialResult[1]((prev) => prev));
+        act(() => initialResult[1].setState((prev) => prev));
         expect(result.current).toBe(initialResult);
     });
 

--- a/packages/react/src/__tests__/useOptic.test.tsx
+++ b/packages/react/src/__tests__/useOptic.test.tsx
@@ -77,4 +77,34 @@ describe('useOptic', () => {
             expect(result.current[0]).toEqual({ name: 'foobar', contact: contactOptic });
         });
     });
+    describe('getOptics', () => {
+        it('should return referentially stable optics', () => {
+            const usersOptic = createState([{ name: 'John' }, { name: 'Jeanne' }, { name: 'Vincent' }]);
+
+            const { getOptics } = renderHook(() => useOptic(usersOptic)).result.current[1];
+            const userOptics = getOptics((user) => user.name);
+
+            act(() => usersOptic.set((prev) => [{ name: 'Marie' }, ...prev]));
+
+            const newUserOptics = getOptics((user) => user.name);
+            userOptics.forEach(([, optic], index) => expect(optic).toBe(newUserOptics[index + 1][1]));
+        });
+    });
+    describe('getOpticsFromMapping', () => {
+        it('should return referentially stable optics', () => {
+            const stateOptic = createState([
+                { country: 'USA', users: [{ name: 'John' }] },
+                { country: 'France', users: [{ name: 'Jeanne' }, { name: 'Vincent' }] },
+            ]);
+            const mappedUsersOptic = stateOptic.map().users.map();
+
+            const { getOpticsFromMapping } = renderHook(() => useOptic(mappedUsersOptic)).result.current[1];
+            const userOptics = getOpticsFromMapping((user) => user.name);
+
+            act(() => stateOptic.set((prev) => [{ country: 'España', users: [{ name: 'José' }] }, ...prev]));
+
+            const newUserOptics = getOpticsFromMapping((user) => user.name);
+            userOptics.forEach(([, optic], index) => expect(optic).toBe(newUserOptics[index + 1][1]));
+        });
+    });
 });

--- a/packages/react/src/useOptic.ts
+++ b/packages/react/src/useOptic.ts
@@ -9,6 +9,11 @@ import {
     GetOpticScope,
     FocusedValue,
     AsyncReadOptic,
+    Resolve,
+    total,
+    mapped,
+    opticsFromKey,
+    opticsFromKeyMapped,
 } from '@optics/state';
 
 export type UseOpticOptions = GetStateOptions;
@@ -17,20 +22,41 @@ export type Setter<T> = {
     setState: Dispatch<SetStateAction<T>>;
 };
 
+type GetOptics<TOptic extends ReadOptic<any, OpticScope>> = GetOpticFocus<TOptic> extends infer T extends any[]
+    ? {
+          getOptics: (
+              getKey: (t: T[number]) => string,
+          ) => readonly [key: string, optic: Resolve<TOptic, T[number], total>][];
+      }
+    : {};
+
+type GetOpticsFromMapping<TOptic extends ReadOptic<any, OpticScope>> = [
+    GetOpticFocus<TOptic>,
+    GetOpticScope<TOptic>,
+] extends [infer T, mapped]
+    ? {
+          getOpticsFromMapping: (
+              getKey: (t: T) => string,
+          ) => readonly [key: string, optic: Resolve<TOptic, T, total>][];
+      }
+    : {};
+
+type SubscriptionResults<TOptic extends ReadOptic<any, OpticScope>> = GetOptics<TOptic> & GetOpticsFromMapping<TOptic>;
+
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(
     optic: TOptic,
 ): [GetOpticFocus<TOptic>, GetOpticScope<TOptic>] extends [infer TFocus, infer TScope extends OpticScope]
     ? AsyncReadOptic<TFocus, TScope> extends TOptic
-        ? [FocusedValue<TFocus, TScope>]
-        : [FocusedValue<TFocus, TScope>, Setter<TFocus>]
+        ? [FocusedValue<TFocus, TScope>, SubscriptionResults<TOptic>]
+        : [FocusedValue<TFocus, TScope>, Setter<TFocus> & SubscriptionResults<TOptic>]
     : never;
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>, TOptions extends UseOpticOptions>(
     optic: TOptic,
     options: TOptions,
 ): [GetOpticFocus<TOptic>, GetOpticScope<TOptic>] extends [infer TFocus, infer TScope extends OpticScope]
     ? AsyncReadOptic<TFocus, TScope> extends TOptic
-        ? [ResolvedType<TFocus, TScope, TOptions>]
-        : [ResolvedType<TFocus, TScope, TOptions>, Setter<TFocus>]
+        ? [ResolvedType<TFocus, TScope, TOptions>, SubscriptionResults<TOptic>]
+        : [ResolvedType<TFocus, TScope, TOptions>, Setter<TFocus> & SubscriptionResults<TOptic>]
     : never;
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(optic: TOptic, options?: UseOpticOptions) {
     const { denormalize } = { denormalize: false, ...(options ?? {}) };
@@ -46,5 +72,9 @@ export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(optic: TOpti
 
     const setState = useMemo(() => (optic as Optic<any, OpticScope>)?.set.bind(optic), [optic]);
 
-    return [slice, { setState }];
+    const getOptics = useMemo(() => opticsFromKey(optic as any), [optic]);
+
+    const getOpticsFromMapping = useMemo(() => opticsFromKeyMapped(optic as any), [optic]);
+
+    return [slice, { setState, getOptics, getOpticsFromMapping }];
 }

--- a/packages/react/src/useOptic.ts
+++ b/packages/react/src/useOptic.ts
@@ -13,12 +13,16 @@ import {
 
 export type UseOpticOptions = GetStateOptions;
 
+export type Setter<T> = {
+    setState: Dispatch<SetStateAction<T>>;
+};
+
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(
     optic: TOptic,
 ): [GetOpticFocus<TOptic>, GetOpticScope<TOptic>] extends [infer TFocus, infer TScope extends OpticScope]
     ? AsyncReadOptic<TFocus, TScope> extends TOptic
         ? [FocusedValue<TFocus, TScope>]
-        : [FocusedValue<TFocus, TScope>, Dispatch<SetStateAction<TFocus>>]
+        : [FocusedValue<TFocus, TScope>, Setter<TFocus>]
     : never;
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>, TOptions extends UseOpticOptions>(
     optic: TOptic,
@@ -26,7 +30,7 @@ export function useOptic<TOptic extends ReadOptic<any, OpticScope>, TOptions ext
 ): [GetOpticFocus<TOptic>, GetOpticScope<TOptic>] extends [infer TFocus, infer TScope extends OpticScope]
     ? AsyncReadOptic<TFocus, TScope> extends TOptic
         ? [ResolvedType<TFocus, TScope, TOptions>]
-        : [ResolvedType<TFocus, TScope, TOptions>, Dispatch<SetStateAction<TFocus>>]
+        : [ResolvedType<TFocus, TScope, TOptions>, Setter<TFocus>]
     : never;
 export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(optic: TOptic, options?: UseOpticOptions) {
     const { denormalize } = { denormalize: false, ...(options ?? {}) };
@@ -40,7 +44,7 @@ export function useOptic<TOptic extends ReadOptic<any, OpticScope>>(optic: TOpti
 
     const slice = useSyncExternalStore(subscribe, getSnapshot);
 
-    const setSlice = useMemo(() => (optic as Optic<any, OpticScope>)?.set.bind(optic), [optic]);
+    const setState = useMemo(() => (optic as Optic<any, OpticScope>)?.set.bind(optic), [optic]);
 
-    return [slice, setSlice];
+    return [slice, { setState }];
 }

--- a/packages/state/src/__tests__/opticsFromKey.test.ts
+++ b/packages/state/src/__tests__/opticsFromKey.test.ts
@@ -6,10 +6,7 @@ describe('opticsFromKey', () => {
         describe('derive optics with each focused on an element from a key', () => {
             const arrayOptic = createState([1, 2, 3, 4, 5]);
 
-            const derivedOptics = opticsFromKey({
-                optic: arrayOptic,
-                getKey: (n) => n.toString(),
-            })().map(([, optic]) => optic);
+            const derivedOptics = opticsFromKey(arrayOptic)((n) => n.toString()).map(([, optic]) => optic);
 
             const listeners = derivedOptics.map((optic) => {
                 const listener = jest.fn();
@@ -39,16 +36,13 @@ describe('opticsFromKey', () => {
         describe('referential stability for the same key', () => {
             const arrayOptic = createState([1, 2, 3, 4, 5]);
 
-            const deriveOptics = opticsFromKey({
-                optic: arrayOptic,
-                getKey: (n) => n.toString(),
-            });
-            const initialOptics = deriveOptics().map(([, optic]) => optic);
+            const deriveOptics = opticsFromKey(arrayOptic);
+            const initialOptics = deriveOptics((n) => n.toString()).map(([, optic]) => optic);
 
             arrayOptic.set((prev) => [prev[0] - 1, ...prev]);
             arrayOptic.set((prev) => [prev[0] - 1, ...prev]);
 
-            const newOptics = deriveOptics().map(([, optic]) => optic);
+            const newOptics = deriveOptics((n) => n.toString()).map(([, optic]) => optic);
 
             it("should return the same optic for an element even if it's moved", () => {
                 expect(initialOptics.every((optic, i) => optic === newOptics[i + 2])).toBe(true);
@@ -58,13 +52,10 @@ describe('opticsFromKey', () => {
     });
 
     describe('with mapped optic', () => {
-        describe.only('derive optics with each focused on an element from a key', () => {
+        describe('derive optics with each focused on an element from a key', () => {
             const arrayOptic = createState([1, 2, 3, 4, 5]);
             const mappedOptic = arrayOptic.map();
-            const derivedOptics = opticsFromKeyMapped({
-                optic: mappedOptic,
-                getKey: (n) => n.toString(),
-            })().map(([, optic]) => optic);
+            const derivedOptics = opticsFromKeyMapped(mappedOptic)((n) => n.toString()).map(([, optic]) => optic);
             const listeners = derivedOptics.map((optic) => {
                 const listener = jest.fn();
                 optic.subscribe(listener, { denormalize: false });
@@ -93,16 +84,13 @@ describe('opticsFromKey', () => {
             const arrayOptic = createState([1, 2, 3, 4, 5]);
             const mappedOptic = arrayOptic.map();
 
-            const deriveOptics = opticsFromKeyMapped({
-                optic: mappedOptic,
-                getKey: (n) => n.toString(),
-            });
-            const initialOptics = deriveOptics().map(([, optic]) => optic);
+            const deriveOptics = opticsFromKeyMapped(mappedOptic);
+            const initialOptics = deriveOptics((n) => n.toString()).map(([, optic]) => optic);
 
             arrayOptic.set((prev) => [prev[0] - 1, ...prev]);
             arrayOptic.set((prev) => [prev[0] - 1, ...prev]);
 
-            const newOptics = deriveOptics().map(([, optic]) => optic);
+            const newOptics = deriveOptics((n) => n.toString()).map(([, optic]) => optic);
 
             it("should return the same optic for an element even if it's moved", () => {
                 expect(initialOptics.every((optic, i) => optic === newOptics[i + 2])).toBe(true);

--- a/packages/state/src/opticsFromKey.ts
+++ b/packages/state/src/opticsFromKey.ts
@@ -2,16 +2,12 @@ import { ReduceValue, mapped, partial } from '@optics/core';
 import { ReadOptic } from './Optics/ReadOptic';
 import { GetOpticFocus, Resolve } from './types';
 
-export const opticsFromKey = <TOptic extends ReadOptic<T, partial>, T extends any[] = GetOpticFocus<TOptic>>({
-    getKey,
-    optic,
-}: {
-    optic: TOptic;
-    getKey: (t: T) => string;
-}): (() => readonly [key: string, optic: Resolve<TOptic, T[number], partial>][]) => {
+export const opticsFromKey = <TOptic extends ReadOptic<T, partial>, T extends any[] = GetOpticFocus<TOptic>>(
+    optic: TOptic,
+): ((getKey: (t: T[number]) => string) => readonly [key: string, optic: Resolve<TOptic, T[number], partial>][]) => {
     let cache: Record<string, ReadOptic<any, partial>> = {};
 
-    return () => {
+    return (getKey) => {
         let previousS: T;
         let elemByKey: Record<string, T[number]>;
 
@@ -42,16 +38,12 @@ export const opticsFromKey = <TOptic extends ReadOptic<T, partial>, T extends an
     };
 };
 
-export const opticsFromKeyMapped = <TOptic extends ReadOptic<T, mapped>, T = GetOpticFocus<TOptic>>({
-    optic,
-    getKey,
-}: {
-    optic: TOptic;
-    getKey: (t: T) => string;
-}): (() => (readonly [key: string, optic: Resolve<TOptic, T, partial>])[]) => {
+export const opticsFromKeyMapped = <TOptic extends ReadOptic<T, mapped>, T = GetOpticFocus<TOptic>>(
+    optic: TOptic,
+): ((getKey: (t: T) => string) => (readonly [key: string, optic: Resolve<TOptic, T, partial>])[]) => {
     let cache: Record<string, ReadOptic<T, partial>> = {};
 
-    return () => {
+    return (getKey) => {
         let elemByKey: Record<string, ReduceValue<T>>;
         const mappedOptic = optic.reduce((s) => {
             elemByKey = Object.fromEntries(s.map((elem) => [getKey(elem.value), elem]));


### PR DESCRIPTION
Add two functions to narrow the type of an optic that's been subscribed to.

- `whenValue` narrows the optic scope from `partial` to `total`.
- `whenType` narrows the focused type thanks to the provided type-guard.

Both of these functions return `null` if the narrowing fails.
Both of these functions are returned by `useOptic`, and thus can only be used if the component has subscribed to the optic.