### PR TITLE
Fix bug with DataOptic focused on undefined

### DIFF
--- a/packages/core/src/__tests__/DataOptic.test.ts
+++ b/packages/core/src/__tests__/DataOptic.test.ts
@@ -10,6 +10,12 @@ describe('DataOptic', () => {
         expect(newValue).toEqual({ a: { b: 2 }, aa: false });
     });
 
+    it('should return undefined when the value is undefined', () => {
+        const value = undefined as { a: 'test' } | undefined;
+        const result = focusOn(value).a.get();
+        expect(result).toBe(undefined);
+    });
+
     describe('partial', () => {
         type TestObj = { a: { b?: { c: number } } };
         const testObj: TestObj = { a: {} };

--- a/packages/core/src/proxify.ts
+++ b/packages/core/src/proxify.ts
@@ -3,7 +3,7 @@ import { Lens } from './types';
 export const proxify = (target: any) => {
     return new Proxy(target, {
         get(target: { instantiate: (lens: Lens[]) => any } & Record<string, any>, prop: any) {
-            if (target[prop] !== undefined) {
+            if (prop in target) {
                 return target[prop];
             }
             if (typeof prop === 'symbol') return;


### PR DESCRIPTION
Resolve bug where DataOptic.get would return a new DataOptic if focused on `undefined`.
issue https://github.com/TSOptics/optics/issues/21